### PR TITLE
Fix: custom gate fixes, changes...

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,17 +1,32 @@
 #discourse-modal.gate {
-  .custom-gate {
-    text-align: center;
-    img {
-      width: #{$custom_gate_image_width};
-      height: auto;
-      margin-bottom: 0.75em;
+  // if custom gate enabled
+  &.custom-gate {
+    .modal-inner-container {
+      background-color: #{$custom_gate_background_color};
     }
-    h2 {
-      color: #{$custom_gate_big_text_color};
+    .modal-footer {
+      color: #{$custom_gate_link_color};
+      a {
+       color: #{$custom_gate_link_color};
+      }
     }
-    p {
-      color: #{$custom_gate_little_text_color};
+    .custom-gate-content {
+      text-align: center;
+      img {
+        width: #{$custom_gate_image_width};
+        height: auto;
+        margin-bottom: 0.75em;
+      }
+      h2 {
+        color: #{$custom_gate_big_text_color};
+      }
+      p {
+        color: #{$custom_gate_little_text_color};
+      }
     }
+  }
+  .modal-inner-container {
+    background-color: var(--secondary);
   }
   .modal-header {
     border-bottom: none;
@@ -20,16 +35,13 @@
     padding: 0 1em;
   }
   .modal-footer {
-    color: #{$custom_gate_link_color};
+    color: var(--primary-medium);
     justify-content: #{$gate_footer_position};
     a {
-      color: #{$custom_gate_link_color};
+      color: var(--primary-medium);
       outline: none;
       margin: 0 0.25em;
     }
-  }
-  .modal-inner-container {
-    background-color: #{$custom_gate_background_color};
   }
   #login-buttons {
     margin-bottom: 0;

--- a/javascripts/discourse/lib/show-gate.js
+++ b/javascripts/discourse/lib/show-gate.js
@@ -8,6 +8,10 @@ export default function(name, opts) {
   const modalController = route.controllerFor('modal');
 
   modalController.set('modalClass', 'gate');
+  
+  if (settings.custom_gate_enabled) {
+    modalController.set('modalClass', 'gate custom-gate');
+  }
 
   const controllerName = opts.admin ? `modals/${name}` : name;
 

--- a/javascripts/discourse/templates/guest-gate.hbs
+++ b/javascripts/discourse/templates/guest-gate.hbs
@@ -1,7 +1,7 @@
 {{#if (theme-setting 'dismissable_false')}}
   {{#d-modal-body title=(theme-prefix 'guest_gate.title') dismissable=false}}
     {{#if (theme-setting 'custom_gate_enabled') }}
-      <div class="custom-gate">
+      <div class="custom-gate-content">
         <img src="{{theme-setting 'custom_gate_image'}}"/>
         <h2>{{theme-i18n "custom_gate.big_text"}}</h2>
         <p>{{theme-i18n "custom_gate.little_text"}}</p>
@@ -17,11 +17,11 @@
   {{else}}
   {{#d-modal-body title=(theme-prefix 'guest_gate.title')}}
     {{#if (theme-setting 'custom_gate_enabled') }}
-      <div class="custom-gate">
+      <div class="custom-gate-content">
         <img src="{{theme-setting 'custom_gate_image'}}"/>
         <h2>{{theme-i18n "custom_gate.big_text"}}</h2>
         <p>{{theme-i18n "custom_gate.little_text"}}</p>
-      </div>
+      </div>     
       {{else}}
       <div>
         <p>{{replace-emoji (i18n 'signup_cta.intro')}}</p>

--- a/settings.yml
+++ b/settings.yml
@@ -4,13 +4,15 @@ guest_gate_enabled:
 max_guest_topic_views:
   type: string
   default: "1"
+  description: Number of topic views until gate displays. After the gate first appears, it appears randomly between 1 and this number.
 dismissable_false:
   type: bool
   default: false
+  description: Removes the close button and lock the modal so visitors can't close it.
 use_gate_buttons:
   type: bool
   default: false
-  description: Use buttons instead of text.
+  description: Use buttons on modal footer instead of links.
 redirect_to_home:
   type: bool
   default: false
@@ -21,10 +23,11 @@ gate_footer_position:
   choices:
     - left
     - right
-  description: Footer buttons position.
+  description: Footer buttons/links position.
 gate_show_only_once:
   type: bool
   default: false
+  description: Guest Gate modal show only once per session.
 custom_gate_enabled:
   type: bool
   default: false


### PR DESCRIPTION
**This update contains fixes/devs:**

* The modal uses custom gate colors also if custom gate was disable. It had to some changes. ⬇️ 
* Renamed the .custom-gate to .custom-gate-content
* Added the `.custom-gate` to `modalClass` next to(`.d-modal`) (not to `modal-body`) if custom gate enabled. This way we can target the whole modal (header, body, footer) not just the custom content section.
* Modify the `common.scss` to fit the new template.
* Added some description to settings...
