### PR TITLE
Feature: abality to change guest gate buttons url

### DIFF
--- a/javascripts/discourse/templates/guest-gate.hbs
+++ b/javascripts/discourse/templates/guest-gate.hbs
@@ -38,20 +38,20 @@
     {{d-button class=(theme-setting 'signup_button_style') label=(theme-prefix 'guest_gate.sign_up') action="showCreateAccount"}}
     {{else}}
     {{#if (theme-setting 'use_gate_buttons') }}
-      {{#if (theme-setting 'redirect_to_home') }}
-        {{d-button class=(theme-setting 'login_button_style') label=(theme-prefix 'guest_gate.log_in') href="/login"}}
-        {{d-button class=(theme-setting 'signup_button_style') label=(theme-prefix 'guest_gate.sign_up') href="/signup"}}
+      {{#if (theme-setting 'custom_url_enabled') }}
+        {{d-button class=(theme-setting 'login_button_style') label=(theme-prefix 'guest_gate.log_in') href=(theme-setting 'custom_login_url')}}
+        {{d-button class=(theme-setting 'signup_button_style') label=(theme-prefix 'guest_gate.sign_up') href=(theme-setting 'custom_signup_url')}}
         {{else}}
         {{d-button class=(theme-setting 'login_button_style') label=(theme-prefix 'guest_gate.log_in') action="showLogin"}}
-        {{d-button class=(theme-setting 'signup_button_style') label=(theme-prefix 'guest_gate.sign_up') action="showCreateAccount"}}
-      {{/if}}
+        {{d-button class=(theme-setting 'signup_button_style') label=(theme-prefix 'guest_gate.sign_up') action="showCreateAccount"}}        
+      {{/if}} 
       {{else}}
-      {{#if (theme-setting 'redirect_to_home') }}
-        <a href="/login">{{theme-i18n "guest_gate.log_in"}}</a> |
-        <a href="/signup">{{theme-i18n "guest_gate.sign_up"}}</a>
+      {{#if (theme-setting 'custom_url_enabled') }}
+        <a href="{{theme-setting 'custom_login_url'}}">{{theme-i18n "guest_gate.log_in"}}</a> |
+        <a href="{{theme-setting 'custom_signup_url'}}">{{theme-i18n "guest_gate.sign_up"}}</a>
         {{else}}
         <a href {{action "showLogin"}}>{{theme-i18n "guest_gate.log_in"}}</a> |
-        <a href {{action "showCreateAccount"}}>{{theme-i18n "guest_gate.sign_up"}}</a>
+        <a href {{action "showCreateAccount"}}>{{theme-i18n "guest_gate.sign_up"}}</a>        
       {{/if}}
     {{/if}}
   {{/if}}

--- a/javascripts/discourse/templates/guest-gate.hbs
+++ b/javascripts/discourse/templates/guest-gate.hbs
@@ -12,7 +12,7 @@
         <p>{{replace-emoji (i18n 'signup_cta.value_prop')}}</p>
       </div>
     {{/if}}
-    {{login-buttons externalLogin=(action "externalLogin")}}  
+    {{login-buttons externalLogin=(action "externalLogin")}}
   {{/d-modal-body}}
   {{else}}
   {{#d-modal-body title=(theme-prefix 'guest_gate.title')}}
@@ -21,14 +21,14 @@
         <img src="{{theme-setting 'custom_gate_image'}}"/>
         <h2>{{theme-i18n "custom_gate.big_text"}}</h2>
         <p>{{theme-i18n "custom_gate.little_text"}}</p>
-      </div>     
+      </div>
       {{else}}
       <div>
         <p>{{replace-emoji (i18n 'signup_cta.intro')}}</p>
         <p>{{replace-emoji (i18n 'signup_cta.value_prop')}}</p>
       </div>
     {{/if}}
-    {{login-buttons externalLogin=(action "externalLogin")}}  
+    {{login-buttons externalLogin=(action "externalLogin")}}
   {{/d-modal-body}}
 {{/if}}
 
@@ -43,15 +43,15 @@
         {{d-button class=(theme-setting 'signup_button_style') label=(theme-prefix 'guest_gate.sign_up') href=(theme-setting 'custom_signup_url')}}
         {{else}}
         {{d-button class=(theme-setting 'login_button_style') label=(theme-prefix 'guest_gate.log_in') action="showLogin"}}
-        {{d-button class=(theme-setting 'signup_button_style') label=(theme-prefix 'guest_gate.sign_up') action="showCreateAccount"}}        
-      {{/if}} 
+        {{d-button class=(theme-setting 'signup_button_style') label=(theme-prefix 'guest_gate.sign_up') action="showCreateAccount"}}
+      {{/if}}
       {{else}}
       {{#if (theme-setting 'custom_url_enabled') }}
         <a href="{{theme-setting 'custom_login_url'}}">{{theme-i18n "guest_gate.log_in"}}</a> |
         <a href="{{theme-setting 'custom_signup_url'}}">{{theme-i18n "guest_gate.sign_up"}}</a>
         {{else}}
         <a href {{action "showLogin"}}>{{theme-i18n "guest_gate.log_in"}}</a> |
-        <a href {{action "showCreateAccount"}}>{{theme-i18n "guest_gate.sign_up"}}</a>        
+        <a href {{action "showCreateAccount"}}>{{theme-i18n "guest_gate.sign_up"}}</a>
       {{/if}}
     {{/if}}
   {{/if}}

--- a/settings.yml
+++ b/settings.yml
@@ -26,6 +26,18 @@ redirect_to_home:
   type: bool
   default: false
   description: Redirect the visitor after click the Login or Signup button to the homepage and open Login or Signup modal.
+custom_url_enabled:
+  type: bool
+  default: false
+  description: Enable custom url for Guest Gate Login and Sing Up button / link.
+custom_login_url:
+  type: string
+  default: "/login"
+  description: Add custom url to Guest Gate Login button / link. By default it is redirect to home page and open login modal.
+custom_signup_url:
+  type: string
+  default: "/signup"
+  description: Add custom url to Guest Gate Sign Up button / link. By default it is redirect to home page and open signup modal.
 gate_footer_position:
   default: center
   type: enum

--- a/settings.yml
+++ b/settings.yml
@@ -22,22 +22,18 @@ signup_button_style:
   choices:
     - btn-primary
   description: Guest Gate Signup button style. btn-primary is a blue (tertiary) colored button by default. btn-default is a grey (primary-low) colored button by default.
-redirect_to_home:
-  type: bool
-  default: false
-  description: Redirect the visitor after click the Login or Signup button to the homepage and open Login or Signup modal.
 custom_url_enabled:
   type: bool
   default: false
-  description: Enable custom url for Guest Gate Login and Sing Up button / link.
+  description: Enable custom url for Guest Gate Login and Sing Up button / link. By default this is redirect the visitor after click the Guest Gate Login or Signup button to the homepage and open Login or Signup modal
 custom_login_url:
   type: string
   default: "/login"
-  description: Add custom url to Guest Gate Login button / link. By default it is redirect to home page and open login modal.
+  description: Add custom url to Guest Gate Login button / link. By default (/login) this is redirect to home page and open login modal.
 custom_signup_url:
   type: string
   default: "/signup"
-  description: Add custom url to Guest Gate Sign Up button / link. By default it is redirect to home page and open signup modal.
+  description: Add custom url to Guest Gate Sign Up button / link. By default (/signup) this is redirect to home page and open signup modal.
 gate_footer_position:
   default: center
   type: enum


### PR DESCRIPTION
This update change the `redirect_to_home` setting to `custom_url_enabled` and add two more option to change the Guest Gate Login and Sign Up buttons url. By default this is replace the redirect_to_home setting.

Settings:
`custom_login_url`: /login (by default this is redirect to home page and open login modal)
`custom_signup_url:` /signup (by default this is redirect to home page and open signup modal)