### PR TITLE
Fix: Discourse Connect Log In button

### DIFF
--- a/javascripts/discourse/controllers/guest-gate.js
+++ b/javascripts/discourse/controllers/guest-gate.js
@@ -4,7 +4,7 @@ import { setting } from 'discourse/lib/computed';
 export default Ember.Controller.extend(ModalFunctionality, {
   login: Ember.inject.controller(),
 
-  ssoEnabled: setting('enable_sso'),
+  ssoEnabled: setting('enable_discourse_connect'),
 
   actions: {
     externalLogin(provider) {

--- a/javascripts/discourse/templates/guest-gate.hbs
+++ b/javascripts/discourse/templates/guest-gate.hbs
@@ -34,8 +34,11 @@
 
 <div class="modal-footer">
   {{#if ssoEnabled}}
-    {{d-button class=(theme-setting 'login_button_style') label=(theme-prefix 'guest_gate.log_in') action="showLogin"}} {{theme-i18n "guest_gate.or"}}
-    {{d-button class=(theme-setting 'signup_button_style') label=(theme-prefix 'guest_gate.sign_up') action="showCreateAccount"}}
+    {{#if (theme-setting 'use_gate_buttons') }}
+      {{d-button class=(theme-setting 'login_button_style') label=(theme-prefix 'guest_gate.sso_log_in') action="showLogin"}}
+      {{else}}
+      <a href {{action "showLogin"}}>{{theme-i18n "guest_gate.sso_log_in"}}</a>
+    {{/if}}
     {{else}}
     {{#if (theme-setting 'use_gate_buttons') }}
       {{#if (theme-setting 'custom_url_enabled') }}
@@ -47,10 +50,12 @@
       {{/if}}
       {{else}}
       {{#if (theme-setting 'custom_url_enabled') }}
-        <a href="{{theme-setting 'custom_login_url'}}">{{theme-i18n "guest_gate.log_in"}}</a> |
+        <a href="{{theme-setting 'custom_login_url'}}">{{theme-i18n "guest_gate.log_in"}}</a>
+        {{theme-i18n "guest_gate.or"}}
         <a href="{{theme-setting 'custom_signup_url'}}">{{theme-i18n "guest_gate.sign_up"}}</a>
         {{else}}
-        <a href {{action "showLogin"}}>{{theme-i18n "guest_gate.log_in"}}</a> |
+        <a href {{action "showLogin"}}>{{theme-i18n "guest_gate.log_in"}}</a>
+        {{theme-i18n "guest_gate.or"}}
         <a href {{action "showCreateAccount"}}>{{theme-i18n "guest_gate.sign_up"}}</a>
       {{/if}}
     {{/if}}

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -4,6 +4,7 @@ en:
     sign_up_email: "Sign Up with Email"
     sign_up: "Sign Up"
     log_in: "I already have an account"
+    sso_log_in: "Log In"
     or: "or"
   custom_gate:
     big_text: "Custom Big text"


### PR DESCRIPTION
This update removes signup button when Discourse Connect enabled and only show a Log In button. I also added different text to Discourse Connect login button `guest_gate.sso_log_in`. Which you can find under theme translations, the default text **Log In**. This update also add a custom text `guest_gate.or` default **or** separator which appears between login and signup links. Only appear when you use links and not buttons.